### PR TITLE
Implement base structure for robust runtime exception handling

### DIFF
--- a/compiler/src/compiler.cpp
+++ b/compiler/src/compiler.cpp
@@ -23,18 +23,24 @@ namespace compiler
 
     std::expected<CompilerResult, bool> Compiler::Compile(std::vector<std::unique_ptr<parser::ASTNode>> &&tree)
     {
-        for (auto &statement : tree)
+        try
         {
-            statement->Compile(m_Context);
+            for (auto &statement : tree)
+            {
+                statement->Compile(m_Context);
+            }
         }
-
+        catch(const CompilerException& err)
+        {
+            return std::unexpected(true); 
+        }
+        
         if(m_Context.ErrorThrown())
         {
           return std::unexpected(true);
         }
 
         CompilerResult result = m_Context.GetResult();
-         
         return result;
     }
 }

--- a/compiler/src/compiler_context.cpp
+++ b/compiler/src/compiler_context.cpp
@@ -18,6 +18,7 @@ namespace compiler
         {"integer_div", shared::Opcodes::OP_NATIVE_INT_DIV},
         {"float_div", shared::Opcodes::OP_NATIVE_FLOAT_DIV},
         {"integer_to_string", shared::Opcodes::OP_NATIVE_INT_TO_STR},
+        {"float_to_string", shared::Opcodes::OP_NATIVE_FLOAT_TO_STR},
         {"negate_integer", shared::Opcodes::OP_NATIVE_UNARY_NEGATE_INT},
         {"negate_float", shared::Opcodes::OP_NATIVE_UNARY_NEGATE_FLOAT},
         {"integer_to_string", shared::Opcodes::OP_NATIVE_INT_TO_STR}

--- a/infinitas/src/repl.cpp
+++ b/infinitas/src/repl.cpp
@@ -1,9 +1,9 @@
 #include "repl.h"
 #include "parser/nodes/base_node.h"
+#include "virtual-machine/virtual_machine.h"
 #include <expected>
-#include <print>
 
-ReadEvalPrintLoop::ReadEvalPrintLoop()
+ReadEvalPrintLoop::ReadEvalPrintLoop() : m_LastWorkingState(new vm::VMSnapshot())
 {
     m_Context.m_VM.Register();
 }
@@ -21,9 +21,6 @@ void ReadEvalPrintLoop::PrintBanner()
     std::cout << "Visit https://docs.0xinfinity.dev for documentation." << std::endl;
     std::cout << "This project is open-source and community governed." << std::endl;
     std::cout << "Licensed under Apache 2." << std::endl;
-    std::cout << "============================================================" << std::endl;
-    std::cout << "[BEWARE] Right now runtime errors do not reset virtual-machine state during REPL. In rare cases, this could lead to undefined behavior (2.2.5) for operations executed after a runtime error." << std::endl;
-    std::cout << "[BEWARE] This behavior will be specified soon and the virtual-machine will return to the last successful state." << std::endl;
     std::cout << "============================================================" << std::endl;
 }
 
@@ -73,31 +70,26 @@ void ReadEvalPrintLoop::CompileAndRun(std::string sourceCode)
         return m_Context.m_Compiler.Compile(std::move(nodes));
         
     })
-    .and_then([this](compiler::CompilerResult result) -> std::expected<void, bool>
+    .and_then([this](compiler::CompilerResult result) 
     {
 
         shared::ConstantPool copy(result.m_Constants);
         m_Context.m_Compiler.PassConstants(std::move(copy)); /** @todo This is a first sketch, implement a better system to handle constantpool in between REPL runs. */
 
         vm::VMInterpretProperties interpretProps{std::move(result.m_Instructions), result.m_Constants.MoveConstants()};
-        m_Context.m_VM.Interpret(interpretProps);
+        return m_Context.m_VM.Interpret(interpretProps);
 
-        PostInterpretation();
+    })
+    .and_then([this]() -> std::expected<void, bool>
+    {
+        m_LastWorkingState = m_Context.m_VM.TakeSnapshot();
         return {};
-
     })
     .or_else([this](bool) -> std::expected<void, bool>
     {
+        m_Context.m_VM.RecoverFromSnapshot(m_LastWorkingState.get());
         m_Context.m_Compiler.ResetErrors();
+        LOG_DEBUG("Error hit.");
         return {};
-
     });
-}
-
-void ReadEvalPrintLoop::PostInterpretation()
-{
-    if (m_Context.m_VM.IsHalted())
-        m_Running = false;
-
-    /** This function will expand. */
 }

--- a/infinitas/src/repl.h
+++ b/infinitas/src/repl.h
@@ -27,5 +27,5 @@ private:
 private:
     WorkflowContext m_Context;
 
-    std::unique_ptr<vm::VMSnapshot> m_LastWorkingState;
+    vm::VMSnapshot m_LastWorkingState;
 }; 

--- a/infinitas/src/repl.h
+++ b/infinitas/src/repl.h
@@ -9,15 +9,12 @@
 class ReadEvalPrintLoop
 {
 public:
-    /** Constructor/Deconstructor */
     ReadEvalPrintLoop();
 
 public:
-    /** Public Functions */
     void Run();
 
 private:
-    /** Private Functions and Internal Implementations */
     void PrintBanner();
     void Loop();
     std::string GetUserInput();
@@ -25,10 +22,10 @@ private:
     void PostInterpretation();
 
 private:
-    /** Temporary/State Variables */
     bool m_Running = true;
 
 private:
-    /** Workflow */
     WorkflowContext m_Context;
+
+    std::unique_ptr<vm::VMSnapshot> m_LastWorkingState;
 }; 

--- a/lexer/src/tokenizer.cpp
+++ b/lexer/src/tokenizer.cpp
@@ -158,7 +158,7 @@ namespace lexer
           return FetchNativeType();
         }
         
-        m_ErrorContext.LogCritical(LexerExceptionCodes::EX_LEX_CHAR_MISPLACED, "'_' is misplaced.");
+        m_ErrorContext.LogError(LexerExceptionCodes::EX_LEX_CHAR_MISPLACED, "'_' is misplaced.");
         return std::unexpected<LexerErrorReturn>(true);
     }
 
@@ -305,7 +305,7 @@ namespace lexer
             return shared::Token{shared::TokenType::TOKEN_RIGHT_BRACE, std::string(1, currentCharacter)};
         default:
             Advance();
-            m_ErrorContext.LogCritical(LexerExceptionCodes::EX_LEX_CHAR_UNKNOWN, "Unknown character.");
+            m_ErrorContext.LogError(LexerExceptionCodes::EX_LEX_CHAR_UNKNOWN, "Unknown character.");
             return std::unexpected<LexerErrorReturn>(true);
         }
     }

--- a/parser/src/nodes/print_node.cpp
+++ b/parser/src/nodes/print_node.cpp
@@ -9,7 +9,7 @@ namespace parser
     FunctionCallNode::FunctionCallNode(std::string name, std::vector<ASTNodePtr> arguments, bool isNative)
         : m_Name(name), m_Arguments(std::move(arguments)), m_IsNative(isNative)
     {
-      LOG_DEBUG("Function call called.");
+
     }
 
     void FunctionCallNode::Compile(compiler::CompilerContext &context)

--- a/parser/src/parser.cpp
+++ b/parser/src/parser.cpp
@@ -73,7 +73,7 @@ namespace parser
             return;
         }
 
-        m_ErrorContext.LogCritical(errorCode, errorMessage);
+        m_ErrorContext.LogError(errorCode, errorMessage);
     }
 
     shared::Token Parser::Consume(shared::TokenType expectedToken, SyntaxExceptionCodes errorCode, std::string errorMessage)
@@ -83,7 +83,7 @@ namespace parser
             return Advance();
         }
 
-        m_ErrorContext.LogCritical(errorCode, errorMessage);
+        m_ErrorContext.LogError(errorCode, errorMessage);
         return shared::Token();
     }
 
@@ -134,8 +134,8 @@ namespace parser
             return std::make_unique<GroupingExpression>(std::move(expression));
         }
 
-        m_ErrorContext.LogCritical(SyntaxExceptionCodes::EX_SYNTAX_UNKNOWN, 
-                                     "Parser ran out of path.");
+        m_ErrorContext.LogError(SyntaxExceptionCodes::EX_SYNTAX_UNKNOWN, 
+                                     "Expression was expected.");
         return std::make_unique<ErrorNode>();
     }
 
@@ -206,7 +206,7 @@ namespace parser
     ASTNodePtr Parser::ExpressionStatement()
     {
         ASTNodePtr expression = Expression();
-        Expect(shared::TokenType::TOKEN_STATEMENT_END, SyntaxExceptionCodes::EX_SYNTAX_MISSING_SEMICOLON, "Semicolon (;) is required to end expressions.");
+        Expect(shared::TokenType::TOKEN_STATEMENT_END, SyntaxExceptionCodes::EX_SYNTAX_MISSING_SEMICOLON, "Semicolon (;) is required to end statements.");
         return expression; 
     }
 
@@ -227,7 +227,7 @@ namespace parser
 
     ASTNodePtr Parser::FunctionCall(std::string name, bool isNative)
     {
-        Expect(shared::TokenType::TOKEN_LEFT_PARENTHESIS, SyntaxExceptionCodes::EX_SYNTAX_MISSING_LEFTPAREN, "Function call expected an opening paranthesis '('.");
+        Expect(shared::TokenType::TOKEN_LEFT_PARENTHESIS, SyntaxExceptionCodes::EX_SYNTAX_MISSING_LEFTPAREN, "Function call to '" + name + "' expected an opening paranthesis '('.");
 
         std::vector<ASTNodePtr> arguments;
         arguments.reserve(2); /** @todo An average of native function call arguments. */
@@ -242,7 +242,7 @@ namespace parser
           }
         }
         
-        Expect(shared::TokenType::TOKEN_RIGHT_PARENTHESIS, SyntaxExceptionCodes::EX_SYNTAX_MISSING_RIGHTPAREN, "You must enclose the function arguments with a closing paranthesis ')'.");
+        Expect(shared::TokenType::TOKEN_RIGHT_PARENTHESIS, SyntaxExceptionCodes::EX_SYNTAX_MISSING_RIGHTPAREN, "Function call to '" + name + "' expected a closing paranthesis ')'.");
         return std::make_unique<FunctionCallNode>(name, std::move(arguments), isNative); 
     }
 

--- a/shared/include/shared/constant_pool.h
+++ b/shared/include/shared/constant_pool.h
@@ -1,36 +1,76 @@
 #pragma once
 
 #include <vector>
-#include "logger.h"
 #include "objects/base_object.h"
 
 namespace shared{
-
+    
+    /**
+     * @todo The underlying data type may be inefficient for a constants pool.
+     * std::vector AS IS do not allow the compilation process to determine whether a value already exists.
+     * Either switch to a unordered_map with custom hashing and value-based lookup logic, or implement own container through vector.
+     */
     class ConstantPool
     { 
     public:
-        ConstantPool(std::vector<Types>&& constantPool);
         ConstantPool();
+        ConstantPool(std::vector<Types>&& constantPool);
 
-        ConstantPool(const ConstantPool& constantPool);
+        ~ConstantPool() = default;
+
         ConstantPool(ConstantPool&& constantPool);
+        ConstantPool(const ConstantPool& constantPool);
         
         ConstantPool& operator=(ConstantPool&& other);
         ConstantPool& operator=(const ConstantPool& other);
 
+    public:
+        /**
+         * @brief Inserts a constant to the pool.
+         * @argument Runtime object.
+         */
         void InsertConstant(Types&& constant);
+        
+        /**
+         * @brief Fetches a constant.
+         * @argument Index of the constant.
+         * @returns Runtime object.
+         */
         Types GetConstant(std::size_t index);
         
+        /**
+         * @brief Fetches the size of the Constant Pool.
+         * @returns Size of the pool.
+         */ 
         std::size_t Size() const noexcept;
         
+        /**
+         * @brief Moves the pool.
+         * @returns Contents of constant pool.
+         */
         [[nodiscard]] std::vector<Types> MoveConstants() noexcept;
+
+        /**
+         * @brief Inserts supplied vector of objects to the end of the pool.
+         * @argument Object vector.
+         */
         void InsertConstants(std::vector<Types>&& constants);
+
+        /**
+         * @brief Replaces the storage.
+         * @argument Object vector.
+         */
         void ReplaceConstants(std::vector<Types>&& constants);
 
     private:
+        /** View class comments for potential data-types to consider here.*/
         std::vector<Types> m_Storage;        
 
     private:
+        /**
+         * @brief Clones the storage.
+         * @returns Cloned object vector.
+         */
         std::vector<Types> CloneStorage() const;
     };
 

--- a/shared/include/shared/constant_pool.h
+++ b/shared/include/shared/constant_pool.h
@@ -16,6 +16,7 @@ namespace shared{
         ConstantPool(ConstantPool&& constantPool);
         
         ConstantPool& operator=(ConstantPool&& other);
+        ConstantPool& operator=(const ConstantPool& other);
 
         void InsertConstant(Types&& constant);
         Types GetConstant(std::size_t index);
@@ -28,6 +29,9 @@ namespace shared{
 
     private:
         std::vector<Types> m_Storage;        
+
+    private:
+        std::vector<Types> CloneStorage() const;
     };
 
 }

--- a/shared/include/shared/error_context.h
+++ b/shared/include/shared/error_context.h
@@ -11,20 +11,32 @@ namespace shared
   struct ErrorContext
   {
       bool m_ErrorThrown = false;
-
-      template<typename...ARGS>
-      void LogError(ARGS...args)
+      
+      void LogError(CodeType code, std::string message)
       {
-          static_assert(std::is_constructible_v<ExceptionType, ARGS...>, "Exception cannot be constructed with the supplied arguments");
-          ExceptionType ex(std::forward<ARGS>(args)...);
-          std::cerr << ex.ToString() << std::endl;
+          Log(shared::ExceptionSeverity::EX_SEVERITY_ERROR, code, message);
+          m_ErrorThrown = true;
       }
     
       void LogCritical(CodeType code, std::string message)
       {
-          LogError(shared::ExceptionSeverity::EX_SEVERITY_EXEC_STOP, code, message);
+          Log(shared::ExceptionSeverity::EX_SEVERITY_EXEC_STOP, code, message);
           m_ErrorThrown = true;
       }
+      
+      void ResetErrors() noexcept
+      {
+          m_ErrorThrown = false;
+      }
 
+  private:
+      template<typename...ARGS>
+      void Log(ARGS...args)
+      {
+          static_assert(std::is_constructible_v<ExceptionType, ARGS...>, "Exception cannot be constructed with the supplied arguments");
+          ExceptionType ex(std::forward<ARGS>(args)...);
+          std::cerr << ex.ToString() << std::endl;
+          if (ex.GetSeverity() == shared::ExceptionSeverity::EX_SEVERITY_EXEC_STOP) throw ex;
+      }
   };
 }

--- a/shared/include/shared/exception.h
+++ b/shared/include/shared/exception.h
@@ -6,7 +6,6 @@
 
 namespace shared
 {
-
    enum class ExceptionLocation : std::uint8_t
     {
       EX_TYPE_UNKNOWN = 0,
@@ -53,5 +52,4 @@ namespace shared
     private:
       ExceptionData m_Data; 
     }; 
-    
 }

--- a/shared/include/shared/exception.h
+++ b/shared/include/shared/exception.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <stdexcept>
 
 namespace shared
 {
@@ -33,7 +34,7 @@ namespace shared
       std::string m_Message;
     };
 
-    class Exception 
+    class Exception : public std::runtime_error 
     { 
     public:
       Exception() = delete;

--- a/shared/include/shared/object_visitors.h
+++ b/shared/include/shared/object_visitors.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "shared/objects/base_object.h"
+#include "shared/useful.h"
+
+namespace shared
+{
+    class CopyObject
+    {
+    public:
+        Types operator()(const ObjectPtr& object) const
+        {
+            return object->Clone();
+        }
+
+        template<typename T>
+        Types operator()(const T& all) const
+        {
+            return all;
+        }
+    };
+}

--- a/shared/include/shared/opcodes.h
+++ b/shared/include/shared/opcodes.h
@@ -14,7 +14,7 @@
 
 namespace shared
 {
-    enum Opcodes : uint8_t
+    enum Opcodes : std::uint8_t
     {
         OP_LOAD_CONSTANT = 0x01,
         OP_DECLARE_VARIABLE = 0x02,
@@ -37,9 +37,10 @@ namespace shared
         OP_NATIVE_INT_DIV = 0x19,
         OP_NATIVE_FLOAT_DIV = 0x20,
         OP_NATIVE_INT_TO_STR = 0x21,
-        OP_NATIVE_UNARY_NEGATE_INT = 0x22,
-        OP_NATIVE_UNARY_NEGATE_FLOAT = 0x23,
-        OP_BLOCK_START = 0x24,
-        OP_BLOCK_END = 0x25,
+        OP_NATIVE_FLOAT_TO_STR = 0x22,
+        OP_NATIVE_UNARY_NEGATE_INT = 0x23,
+        OP_NATIVE_UNARY_NEGATE_FLOAT = 0x24,
+        OP_BLOCK_START = 0x25,
+        OP_BLOCK_END = 0x26,
     };
 }

--- a/shared/src/constant_pool.cpp
+++ b/shared/src/constant_pool.cpp
@@ -1,12 +1,11 @@
 #include "shared/constant_pool.h"
-#include <type_traits>
 #include <utility>
 #include "shared/object_visitors.h"
 
 namespace shared
 {
 
-    ConstantPool::ConstantPool(std::vector<Types> &&constantPool)
+    ConstantPool::ConstantPool(std::vector<Types>&& constantPool)
         : m_Storage(std::move(constantPool))
     {
     }

--- a/shared/src/exception.cpp
+++ b/shared/src/exception.cpp
@@ -2,7 +2,7 @@
 
 namespace shared
 {
-  Exception::Exception(ExceptionLocation location, ExceptionSeverity severity, std::uint64_t code, std::string message) : m_Data(location, severity, code, message)
+  Exception::Exception(ExceptionLocation location, ExceptionSeverity severity, std::uint64_t code, std::string message) : m_Data(location, severity, code, message), std::runtime_error(message)
   {
         
   }

--- a/virtual-machine/details/virtual-machine/stack_container.h
+++ b/virtual-machine/details/virtual-machine/stack_container.h
@@ -13,7 +13,6 @@
 #pragma once
 
 #include <vector>
-#include <cstdint>
 
 #include <shared/logger.h>
 #include <shared/constant_pool.h>
@@ -27,7 +26,14 @@ namespace vm
     {
     public:
         StackContainer(std::size_t capacity = 30);
+        StackContainer(const StackContainer& other);
 
+        StackContainer& operator=(const StackContainer& other);
+
+        StackContainer& operator=(StackContainer&& other) = delete;
+        StackContainer(StackContainer&& other) = delete;
+
+    public:
         /**
          * @brief Pushes the value onto the stack by moving the argument. 
          * @param ObjectPtr&& Object pointer to be pushed.
@@ -58,7 +64,6 @@ namespace vm
          */
         [[nodiscard]] Types PopMove();
 
-
         /**
          * @brief Retrieves the size counter.
          */
@@ -67,6 +72,9 @@ namespace vm
     private:
         std::vector<Types> m_Storage;
         std::size_t m_Size;
+
+    private:
+        std::vector<Types> CloneStorage() const;
     };
 
 }

--- a/virtual-machine/include/virtual-machine/environment.h
+++ b/virtual-machine/include/virtual-machine/environment.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <vector>
-#include <unordered_map>
 
 #include <shared/useful.h>
 
@@ -18,7 +17,13 @@ namespace vm
     {
     public:
         Environment();
-    
+
+        Environment(const Environment& other);
+        Environment& operator=(const Environment& other);
+
+        Environment(Environment&& other) = delete;
+        Environment& operator=(Environment&& other) = delete;
+
     public:
         void AddScope();
         void RemoveScope();
@@ -29,5 +34,8 @@ namespace vm
 
     public:
         std::vector<StackValues> m_Environments;
+
+    private:
+        std::vector<StackValues> CloneStorage() const;
     };
 }

--- a/virtual-machine/include/virtual-machine/exception_runtime.h
+++ b/virtual-machine/include/virtual-machine/exception_runtime.h
@@ -4,24 +4,23 @@
 
 namespace vm
 {
-  enum class RuntimeExceptionCodes : std::uint64_t
-  {
-    EX_RUNTIME_UNKNOWN = 0,
-    EX_RUNTIME_STACK_INVALID = 1,
-    EX_NATIVE_PARAMETER_INVALID = 2,
-    EX_ARITHMETIC_ZERODIVISION = 3,
-  };
+    enum class RuntimeExceptionCodes : std::uint64_t
+    {
+        EX_RUNTIME_UNKNOWN = 0,
+        EX_RUNTIME_STACK_INVALID = 1,
+        EX_NATIVE_PARAMETER_INVALID = 2,
+        EX_ARITHMETIC_ZERODIVISION = 3,
+    };
 
-  class RuntimeException : public shared::Exception
-  {
-  public:
-    using ExceptionCodeType = RuntimeExceptionCodes;
+    class RuntimeException : public shared::Exception
+    {
+    public:
+        using ExceptionCodeType = RuntimeExceptionCodes;
 
-  public:
-    RuntimeException(shared::ExceptionSeverity severity, RuntimeExceptionCodes code, std::string message);
-    ~RuntimeException() { }
+    public:
+        RuntimeException(shared::ExceptionSeverity severity, RuntimeExceptionCodes code, std::string message);
     
-  public:
-    std::string ToString() const override;
-  };
+    public:
+        std::string ToString() const override;
+    };
 }

--- a/virtual-machine/include/virtual-machine/exception_runtime.h
+++ b/virtual-machine/include/virtual-machine/exception_runtime.h
@@ -8,7 +8,8 @@ namespace vm
   {
     EX_RUNTIME_UNKNOWN = 0,
     EX_RUNTIME_STACK_INVALID = 1,
-    EX_ARITHMETIC_ZERODIVISION = 2
+    EX_NATIVE_PARAMETER_INVALID = 2,
+    EX_ARITHMETIC_ZERODIVISION = 3,
   };
 
   class RuntimeException : public shared::Exception

--- a/virtual-machine/include/virtual-machine/executor_cases/all.h
+++ b/virtual-machine/include/virtual-machine/executor_cases/all.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "arithmetic.h"
+#include "type_conversion.h"
 #include "block.h"
 #include "native.h"
 #include "unary.h"

--- a/virtual-machine/include/virtual-machine/executor_cases/exec_utils.h
+++ b/virtual-machine/include/virtual-machine/executor_cases/exec_utils.h
@@ -3,24 +3,44 @@
 #include <expected>
 #include <variant>
 #include <shared/objects/base_object.h>
+#include "virtual-machine/exception_runtime.h"
+#include "virtual-machine/virtual_machine.h"
 
 namespace vm
 {
-    /**
-     * @brief A utility function that checks the type against the supplied template argument.
-     * @returns If matches the supplied type, returns the object as the type specified in template arguments, otherwise a boolean indicating error.
-     */
-    template<typename ExpectedType, typename T>
-    std::expected<ExpectedType, bool> TypeCheck(T&& obj)
+    class ExecutorUtils
     {
-        auto* value = std::get_if<ExpectedType>(&obj);
-        if (value)
+    public:
+        static void AssertStackSizeNotEqual(std::size_t size, std::string function, VMContext& context);    
+        static void AssertStackSizeGreaterEqual(std::size_t size, std::string function, VMContext& context);    
+
+       /**
+       * @brief A utility function that checks the type against the supplied template argument.
+       * @returns If matches the supplied type, returns the object as the type specified in template arguments, otherwise a boolean indicating error.
+       */
+        template<typename ExpectedType, typename T>
+        static ExpectedType TypeCheck(T&& obj, const std::string& function_name, VMContext& context)
         {
-            return *value;
+            auto* value = std::get_if<ExpectedType>(&obj);
+            if (value)
+            {
+                return *value;
+            }
+            
+            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_NATIVE_PARAMETER_INVALID, function_name + ": argument mismatch. Check specifications.");
+            throw;
         }
-        else
-        {
-            return std::unexpected<bool>(true);
-        }
+    };   
+
+    template<typename SrcType, typename DstType>
+    static void ConvertTo(const std::string& function_name, VMContext& context)
+    {
+        ExecutorUtils::AssertStackSizeGreaterEqual(1, function_name, context);
+
+        auto a = ExecutorUtils::TypeCheck<SrcType>(context.m_Stack.PopMove(), function_name, context);
+        
+        DstType result = a;
+
+        context.m_Stack.Push(result);
     }
 }

--- a/virtual-machine/include/virtual-machine/executor_cases/exec_utils.h
+++ b/virtual-machine/include/virtual-machine/executor_cases/exec_utils.h
@@ -27,7 +27,7 @@ namespace vm
                 return *value;
             }
             
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_NATIVE_PARAMETER_INVALID, function_name + ": argument mismatch. Check specifications.");
+            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_NATIVE_PARAMETER_INVALID, function_name + ": argument type mismatch. Check specifications.");
             throw;
         }
     };   

--- a/virtual-machine/include/virtual-machine/executor_cases/type_conversion.h
+++ b/virtual-machine/include/virtual-machine/executor_cases/type_conversion.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "../virtual_machine.h"
+
+namespace vm
+{
+    namespace typeConversion
+    {
+        void IntegerToString(VMContext& context, const shared::Instruction& instruction);
+        void IntegerToFloat(VMContext& context, const shared::Instruction& instruction);
+        void FloatToString(VMContext& context, const shared::Instruction& instruction);
+        void FloatToInteger(VMContext& context, const shared::Instruction& instruction);
+        void StringToFloat(VMContext& context, const shared::Instruction& instruction);
+        void StringToInteger(VMContext& context, const shared::Instruction& instruction);
+    }
+}

--- a/virtual-machine/include/virtual-machine/virtual_machine.h
+++ b/virtual-machine/include/virtual-machine/virtual_machine.h
@@ -12,6 +12,7 @@
 #include "virtual-machine/exception_runtime.h"
 #include "environment.h"
 #include <vector>
+#include <expected>
 
 #include <shared/instruction_container.h>
 #include <shared/constant_pool.h>
@@ -33,24 +34,37 @@ namespace vm
         std::vector<Types>&& m_Constants;
     };
 
+    struct VMSnapshot
+    {
+        std::vector<shared::Instruction> m_Instructions;
+        shared::ConstantPool m_Constants;
+        Environment m_Environment;
+        StackContainer m_Stack;
+        size_t m_InstructionPointer;
+    };
+
     class VirtualMachine
     {
     public:
         VirtualMachine();
-    
+
     public:
         void Register();
-        void Interpret(VMInterpretProperties& props);
+        std::expected<void, bool> Interpret(VMInterpretProperties& props);
         void Dispatch(const shared::Instruction& instruction);
         bool IsHalted() const noexcept;
+        void ResetErrors() noexcept;
+        
+        std::unique_ptr<VMSnapshot> TakeSnapshot();
+        void RecoverFromSnapshot(const VMSnapshot* snapshot);
 
     private:
         std::vector<shared::Instruction> m_Instructions;
         ExecutionDispatcher m_ExecutionDispatcher;
-        Environment m_Environment;
         shared::ConstantPool m_Constants;
-        StackContainer m_Stack;
         size_t m_InstructionPointer;
+        Environment m_Environment;
+        StackContainer m_Stack;
 
         shared::ErrorContext<RuntimeException> m_ErrorContext;
         VMContext m_VMContext;

--- a/virtual-machine/include/virtual-machine/virtual_machine.h
+++ b/virtual-machine/include/virtual-machine/virtual_machine.h
@@ -28,12 +28,22 @@ namespace vm
         shared::ErrorContext<RuntimeException>& m_ErrorContext;
     };
 
+    /**
+     * @brief A props struct for the VirtualMachine::Interpret function.
+     * * Implemented so that the Interpret function is more clear.
+     */
     struct VMInterpretProperties
     {
-        std::vector<shared::Instruction>&& m_Instructions;
-        std::vector<Types>&& m_Constants;
+        std::vector<shared::Instruction> m_Instructions;
+        std::vector<Types> m_Constants;
     };
-
+    
+    /**
+     * @brief Used to keep track of a state of the virtual machine.
+     * * Copies made through this construct can be loaded to an instance of VirtualMachine at any time.
+     *
+     * @warning Instead of copying the entire VirtualMachine, this construct should be used!
+     */ 
     struct VMSnapshot
     {
         std::vector<shared::Instruction> m_Instructions;
@@ -55,8 +65,9 @@ namespace vm
         bool IsHalted() const noexcept;
         void ResetErrors() noexcept;
         
-        std::unique_ptr<VMSnapshot> TakeSnapshot();
-        void RecoverFromSnapshot(const VMSnapshot* snapshot);
+        VMSnapshot TakeSnapshot();
+        void Recover(const VMSnapshot& snapshot);
+        void RecoverFromSnapshot(const VMSnapshot& snapshot);
 
     private:
         std::vector<shared::Instruction> m_Instructions;

--- a/virtual-machine/src/environment.cpp
+++ b/virtual-machine/src/environment.cpp
@@ -1,15 +1,28 @@
 #include "virtual-machine/environment.h"
 
+#include <shared/constant_pool.h>
+#include <shared/object_visitors.h>
 #include <stdexcept>
-
 #include <shared/objects/base_object.h>
-#include <type_traits>
 
 namespace vm
 {
     Environment::Environment()
     {
         /** @todo reserve size. */
+    }
+
+    Environment::Environment(const Environment& other) : m_Environments(other.CloneStorage())
+    {
+
+    }
+    
+    Environment& Environment::operator=(const Environment& other)
+    {
+        if (this == &other) return *this;
+        std::vector<StackValues> temp = other.CloneStorage();
+        m_Environments.swap(temp);
+        return *this;
     }
 
     void Environment::AddScope()
@@ -56,5 +69,22 @@ namespace vm
             throw std::runtime_error("Index is out of bounds for unqualified variable lookup.");
 
         return scope.at(index).m_Object; 
+    }
+    
+    std::vector<StackValues> Environment::CloneStorage() const
+    {
+        std::vector<StackValues> temp;
+        temp.reserve(m_Environments.size());
+        for(const auto& env : m_Environments)
+        {
+            std::vector<EnvironmentValue> envTemp;
+            envTemp.reserve(env.size());
+            for(const auto& elem : env)
+            {
+                envTemp.emplace_back(std::visit(shared::CopyObject{}, elem.m_Object));
+            }
+            temp.emplace_back(std::move(envTemp));
+        }
+        return temp;
     }
 }

--- a/virtual-machine/src/executor_cases/arithmetic.cpp
+++ b/virtual-machine/src/executor_cases/arithmetic.cpp
@@ -1,173 +1,112 @@
 #include "virtual-machine/executor_cases/arithmetic.h"
 
+#include "virtual-machine/exception_runtime.h"
 #include "virtual-machine/executor_cases/exec_utils.h"
 
 namespace vm
 {
     void ArithmeticCases::IntegerAdd(VMContext &context, const shared::Instruction& instruction)
     {
-        if (context.m_Stack.Size() < 2)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__integer_add function requires at least 2 elements loaded on stack.");
-        }
+        ExecutorUtils::AssertStackSizeGreaterEqual(2, "__integer_add", context);
 
-        auto b = TypeCheck<mp::mpz_int>(context.m_Stack.PopMove());
-        auto a = TypeCheck<mp::mpz_int>(context.m_Stack.PopMove());
+        auto b = ExecutorUtils::TypeCheck<mp::mpz_int>(context.m_Stack.PopMove(), __func__, context);
+        auto a = ExecutorUtils::TypeCheck<mp::mpz_int>(context.m_Stack.PopMove(), __func__, context);
         
-        if(!b || !a)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__integer_add function requires 2 ___integer types!");
-            return;
-        }
-
-        mp::mpz_int result = a.value() + b.value(); 
+        mp::mpz_int result = a + b; 
 
         context.m_Stack.Push(std::move(result));
     }
     
     void ArithmeticCases::FloatAdd(VMContext &context, const shared::Instruction& instruction)
     {
-         if (context.m_Stack.Size() < 2)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__float_add function requires at least 2 elements loaded on stack.");
-        }
+        ExecutorUtils::AssertStackSizeGreaterEqual(2, "__float_add", context);
 
-        auto b = TypeCheck<mp::mpf_float>(context.m_Stack.PopMove());
-        auto a = TypeCheck<mp::mpf_float>(context.m_Stack.PopMove());
+        auto b = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.PopMove(), __func__, context);
+        auto a = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.PopMove(), __func__, context);
 
-        if(!b.has_value() || !a.has_value())
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__float_add function requires 2 ___float types!");
-            return;
-        }
-
-        mp::mpf_float result = a.value() + b.value(); 
+        mp::mpf_float result = a + b; 
 
         context.m_Stack.Push(std::move(result));
     }
 
     void ArithmeticCases::IntegerSub(VMContext &context, const shared::Instruction& instruction)
     {
-        if (context.m_Stack.Size() < 2)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__integer_sub function requires at least 2 elements loaded on stack.");
-        }
+        ExecutorUtils::AssertStackSizeGreaterEqual(2, "__integer_sub", context);
 
-        auto b = TypeCheck<mp::mpz_int>(context.m_Stack.PopMove());
-        auto a = TypeCheck<mp::mpz_int>(context.m_Stack.PopMove());
+        auto b = ExecutorUtils::TypeCheck<mp::mpz_int>(context.m_Stack.PopMove(), __func__, context);
+        auto a = ExecutorUtils::TypeCheck<mp::mpz_int>(context.m_Stack.PopMove(), __func__, context);
         
-        if(!b || !a)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__integer_sub function requires 2 ___integer types!");
-            return;
-        }
-
-        mp::mpz_int result = a.value() - b.value(); 
+        mp::mpz_int result = a - b; 
 
         context.m_Stack.Push(std::move(result));
     }
 
     void ArithmeticCases::FloatSub(VMContext &context, const shared::Instruction& instruction)
     {
-         if (context.m_Stack.Size() < 2)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__float_sub function requires at least 2 elements loaded on stack.");
-        }
+        ExecutorUtils::AssertStackSizeGreaterEqual(2, "__float_sub", context);
 
-        auto b = TypeCheck<mp::mpf_float>(context.m_Stack.PopMove());
-        auto a = TypeCheck<mp::mpf_float>(context.m_Stack.PopMove());
+        auto b = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.PopMove(), __func__, context);
+        auto a = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.PopMove(), __func__, context);
 
-        if(!b.has_value() || !a.has_value())
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__float_sub function requires 2 ___float types!");
-            return;
-        }
-
-        mp::mpf_float result = a.value() - b.value(); 
+        mp::mpf_float result = a - b; 
 
         context.m_Stack.Push(std::move(result));
     }
 
     void ArithmeticCases::IntegerMul(VMContext &context, const shared::Instruction& instruction)
     {
-        if (context.m_Stack.Size() < 2)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__integer_mul function requires at least 2 elements loaded on stack.");
-        }
+        ExecutorUtils::AssertStackSizeGreaterEqual(2, "__integer_mul", context);
 
-        auto b = TypeCheck<mp::mpz_int>(context.m_Stack.PopMove());
-        auto a = TypeCheck<mp::mpz_int>(context.m_Stack.PopMove());
+        auto b = ExecutorUtils::TypeCheck<mp::mpz_int>(context.m_Stack.PopMove(), __func__, context);
+        auto a = ExecutorUtils::TypeCheck<mp::mpz_int>(context.m_Stack.PopMove(), __func__, context);
         
-        if(!b || !a)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__integer_mul function requires 2 ___integer types!");
-            return;
-        }
-
-        mp::mpz_int result = a.value() * b.value(); 
+        mp::mpz_int result = a * b; 
 
         context.m_Stack.Push(std::move(result));
     }
 
     void ArithmeticCases::FloatMul(VMContext &context, const shared::Instruction& instruction)
     {
-         if (context.m_Stack.Size() < 2)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__float_mul function requires at least 2 elements loaded on stack.");
-        }
+        ExecutorUtils::AssertStackSizeGreaterEqual(2, "__float_mul", context);
 
-        auto b = TypeCheck<mp::mpf_float>(context.m_Stack.PopMove());
-        auto a = TypeCheck<mp::mpf_float>(context.m_Stack.PopMove());
+        auto b = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.PopMove(), __func__, context);
+        auto a = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.PopMove(), __func__, context);
 
-        if(!b.has_value() || !a.has_value())
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__float_mul function requires 2 ___float types!");
-            return;
-        }
-
-        mp::mpf_float result = a.value() * b.value(); 
+        mp::mpf_float result = a * b; 
 
         context.m_Stack.Push(std::move(result));
     }
 
     void ArithmeticCases::IntegerDiv(VMContext &context, const shared::Instruction& instruction)
     {
-        if (context.m_Stack.Size() < 2)
+        ExecutorUtils::AssertStackSizeGreaterEqual(2, "__integer_div", context);
+
+        auto b = ExecutorUtils::TypeCheck<mp::mpz_int>(context.m_Stack.PopMove(), __func__, context);
+        auto a = ExecutorUtils::TypeCheck<mp::mpz_int>(context.m_Stack.PopMove(), __func__, context);
+       
+        if(b == 0)
         {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__integer_mul function requires at least 2 elements loaded on stack.");
+            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_ARITHMETIC_ZERODIVISION, "__integer_div: Division by zero!");
         }
 
-        auto b = TypeCheck<mp::mpz_int>(context.m_Stack.PopMove());
-        auto a = TypeCheck<mp::mpz_int>(context.m_Stack.PopMove());
-        
-        if(!b || !a)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__integer_mul function requires 2 ___integer types!");
-            return;
-        }
-
-        mp::mpz_int result = a.value() / b.value(); 
+        mp::mpz_int result = a / b; 
 
         context.m_Stack.Push(std::move(result));
     }
 
     void ArithmeticCases::FloatDiv(VMContext &context, const shared::Instruction& instruction)
     {
-         if (context.m_Stack.Size() < 2)
+        ExecutorUtils::AssertStackSizeGreaterEqual(2, "__integer_div", context);
+
+        auto b = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.PopMove(), __func__, context);
+        auto a = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.PopMove(), __func__, context);
+
+        if(b == 0)
         {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__float_mul function requires at least 2 elements loaded on stack.");
+            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_ARITHMETIC_ZERODIVISION, "__float_div: Division by zero!");
         }
 
-        auto b = TypeCheck<mp::mpf_float>(context.m_Stack.PopMove());
-        auto a = TypeCheck<mp::mpf_float>(context.m_Stack.PopMove());
-
-        if(!b.has_value() || !a.has_value())
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__float_mul function requires 2 ___float types!");
-            return;
-        }
-
-        mp::mpf_float result = a.value() / b.value(); 
+        mp::mpf_float result = a / b; 
 
         context.m_Stack.Push(std::move(result));
     }

--- a/virtual-machine/src/executor_cases/exec_utils.cpp
+++ b/virtual-machine/src/executor_cases/exec_utils.cpp
@@ -1,0 +1,18 @@
+#include "virtual-machine/executor_cases/exec_utils.h"
+
+namespace vm
+{
+    void ExecutorUtils::AssertStackSizeNotEqual(std::size_t size, std::string function, VMContext& context)
+    {
+        if (context.m_Stack.Size() == size) return;
+        context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_UNKNOWN, function + ": stack size must be equal to " + std::to_string(size));
+        return;
+    }
+
+    void ExecutorUtils::AssertStackSizeGreaterEqual(std::size_t size, std::string function, VMContext& context)
+    {
+        if (context.m_Stack.Size() >= size) return;
+        context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_UNKNOWN, function + ": stack size must greater than " + std::to_string(size));
+        return;
+    }
+}

--- a/virtual-machine/src/executor_cases/native.cpp
+++ b/virtual-machine/src/executor_cases/native.cpp
@@ -3,25 +3,7 @@
 #include "virtual-machine/exception_runtime.h"
 
 namespace vm
-{
-    void NativeCases::IntegerToString(VMContext& context, const shared::Instruction& instruction)
-    {
-        if(context.m_Stack.Size() < 1)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__integer_to_string function requires an ___integer parameter.");
-            return;
-        }
-        
-        auto a = TypeCheck<mp::mpz_int>(context.m_Stack.PopMove());
-        
-        if(!a.has_value())
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__integer_to_string function requires an ___integer parameter.");
-            return;
-        }
-        
-        context.m_Stack.Push(a.value().str());
-    }
+{ 
     
     void NativeCases::LoadConstant(VMContext &context, const shared::Instruction& instruction)
     {
@@ -33,11 +15,7 @@ namespace vm
      */
     void NativeCases::Print(VMContext &context,const shared::Instruction& instruction)
     {
-        if (context.m_Stack.Size() < instruction.m_Value)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "Stack size mismatch with supplied argument count for __print function.");
-            return;
-        }
+        ExecutorUtils::AssertStackSizeGreaterEqual(instruction.m_Value, "__print", context);
 
         /** @todo Implement stack logic that allows you to peek the elements, print in a single loop, then pop all N number of elements. */
         std::vector<std::string> params;
@@ -46,15 +24,9 @@ namespace vm
         std::ostream &os = std::cout;
         for (std::size_t i = 0; i < instruction.m_Value; i++)
         {
-            auto param = TypeCheck<std::string>(context.m_Stack.PopMove());
+            auto param = ExecutorUtils::TypeCheck<std::string>(context.m_Stack.PopMove(), "__print", context);
 
-            if(!param)
-            {
-                context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__print function arguments must be of type ___string.");
-                return;
-            }
-
-            params.push_back(param.value());
+            params.push_back(param);
         }
 
         for(auto i = params.rbegin(); i != params.rend(); ++i)

--- a/virtual-machine/src/executor_cases/type_conversion.cpp
+++ b/virtual-machine/src/executor_cases/type_conversion.cpp
@@ -1,0 +1,31 @@
+#include "virtual-machine/executor_cases/type_conversion.h"
+
+#include "virtual-machine/executor_cases/exec_utils.h"
+
+namespace vm
+{
+
+    void typeConversion::IntegerToString(VMContext& context, const shared::Instruction& instruction)
+    {
+        ExecutorUtils::AssertStackSizeGreaterEqual(1, "__integer_to_string", context);
+        auto integer = ExecutorUtils::TypeCheck<mp::mpz_int>(context.m_Stack.PopMove(), "__integer_to_string", context);
+        std::string result = integer.str();
+        context.m_Stack.Push(result);
+    }
+    
+    void typeConversion::FloatToString(VMContext& context, const shared::Instruction& instruction)
+    {
+        ExecutorUtils::AssertStackSizeGreaterEqual(1, "__integer_to_string", context);
+        auto integer = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.PopMove(), "__float_to_string", context);
+        std::string result = integer.str();
+        context.m_Stack.Push(result);
+    }
+    
+    void typeConversion::FloatToInteger(VMContext& context, const shared::Instruction& instruction)
+    {
+        ExecutorUtils::AssertStackSizeGreaterEqual(1, "__integer_to_string", context);
+        auto integer = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.PopMove(), "__float_to_string", context);
+        mp::mpz_int result = integer.convert_to<mp::mpz_int>();
+        context.m_Stack.Push(result);
+    }
+}

--- a/virtual-machine/src/executor_cases/type_conversion.cpp
+++ b/virtual-machine/src/executor_cases/type_conversion.cpp
@@ -15,9 +15,9 @@ namespace vm
     
     void typeConversion::FloatToString(VMContext& context, const shared::Instruction& instruction)
     {
-        ExecutorUtils::AssertStackSizeGreaterEqual(1, "__integer_to_string", context);
-        auto integer = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.PopMove(), "__float_to_string", context);
-        std::string result = integer.str();
+        ExecutorUtils::AssertStackSizeGreaterEqual(1, "__float_to_string", context);
+        auto floatingPoint = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.PopMove(), "__float_to_string", context);
+        std::string result = floatingPoint.str();
         context.m_Stack.Push(result);
     }
     

--- a/virtual-machine/src/executor_cases/unary.cpp
+++ b/virtual-machine/src/executor_cases/unary.cpp
@@ -6,37 +6,21 @@ namespace vm
 {
     void UnaryCases::NegateInteger(VMContext &context, const shared::Instruction& instruction)
     {
-        if (context.m_Stack.Size() < 1)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "Negation operation requires the stack to have at least 1 element. Negation cannot be attempted not on a object.");
-        }
+        ExecutorUtils::AssertStackSizeGreaterEqual(1, "__negate_integer", context);
 
-        auto value = TypeCheck<mp::mpz_int>(context.m_Stack.PopMove());
+        auto value = ExecutorUtils::TypeCheck<mp::mpz_int>(context.m_Stack.PopMove(), __func__, context);
     
-        if(!value)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__negate_integer function requires type ___integer as argument!");
-        }
-              
-        mp::mpz_int result = value.value() * -1;
+        mp::mpz_int result = value * -1;
         context.m_Stack.Push(result);
     }
 
     void UnaryCases::NegateFloat(VMContext &context, const shared::Instruction& instruction)
     {
-        if (context.m_Stack.Size() < 1)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "Negation operation requires the stack to have at least 1 element. Negation cannot be attempted not on a object.");
-        }
-
-        auto value = TypeCheck<mp::mpf_float>(context.m_Stack.ReferenceBack());
-    
-        if(!value)
-        {
-            context.m_ErrorContext.LogCritical(RuntimeExceptionCodes::EX_RUNTIME_STACK_INVALID, "__negate_float function requires type ___float as argument!");
-        }
+        ExecutorUtils::AssertStackSizeGreaterEqual(1, "__negate_float", context);
         
-        mp::mpf_float result = value.value() * -1;
+        auto value = ExecutorUtils::TypeCheck<mp::mpf_float>(context.m_Stack.ReferenceBack(), __func__, context);
+    
+        mp::mpf_float result = value * -1;
         context.m_Stack.Push(result);
     }
 }

--- a/virtual-machine/src/register.h
+++ b/virtual-machine/src/register.h
@@ -27,7 +27,9 @@ namespace vm
     dispatcher.Register(shared::Opcodes::OP_LOAD_CONSTANT, &NativeCases::LoadConstant); \
     dispatcher.Register(shared::Opcodes::OP_NATIVE_PRINT, &NativeCases::Print); \
     dispatcher.Register(shared::Opcodes::OP_NATIVE_EXIT, &NativeCases::Exit); \
-    dispatcher.Register(shared::Opcodes::OP_NATIVE_INT_TO_STR, &NativeCases::IntegerToString); \
+        \
+    dispatcher.Register(shared::Opcodes::OP_NATIVE_INT_TO_STR, &typeConversion::IntegerToString); \
+    dispatcher.Register(shared::Opcodes::OP_NATIVE_FLOAT_TO_STR, &typeConversion::FloatToString); \
         \
     dispatcher.Register(shared::Opcodes::OP_NATIVE_UNARY_NEGATE_INT, &UnaryCases::NegateInteger); \
     dispatcher.Register(shared::Opcodes::OP_NATIVE_UNARY_NEGATE_FLOAT, &UnaryCases::NegateFloat); \

--- a/virtual-machine/src/virtual_machine.cpp
+++ b/virtual-machine/src/virtual_machine.cpp
@@ -34,9 +34,7 @@ namespace vm
         m_Instructions.reserve(m_Instructions.capacity() * 2); /** @todo Implement optimization. */
         m_Instructions.insert(m_Instructions.end(), std::make_move_iterator(props.m_Instructions.begin()), std::make_move_iterator(props.m_Instructions.end()));
         m_Constants.ReplaceConstants(std::move(props.m_Constants));
-
         VMLoop();
-
         if(m_IsHalted) return std::unexpected<bool>(true);
         return {};
     }
@@ -53,20 +51,24 @@ namespace vm
         m_ErrorContext.ResetErrors();
     }
 
-    std::unique_ptr<VMSnapshot> VirtualMachine::TakeSnapshot()
+    VMSnapshot VirtualMachine::TakeSnapshot()
     {
-        return std::make_unique<VMSnapshot>(m_Instructions, shared::ConstantPool(m_Constants), m_Environment, m_Stack, m_InstructionPointer);
+        return VMSnapshot(m_Instructions, shared::ConstantPool(m_Constants), m_Environment, m_Stack, m_InstructionPointer);
     }
 
-    void VirtualMachine::RecoverFromSnapshot(const VMSnapshot* snapshot)
+    void VirtualMachine::Recover(const VMSnapshot& snapshot)
     {
         ResetErrors();
-        if(snapshot == nullptr) return;  
-        m_InstructionPointer = snapshot->m_InstructionPointer;
-        m_Instructions = snapshot->m_Instructions;
-        m_Constants = snapshot->m_Constants;
-        m_Environment = snapshot->m_Environment;
-        m_Stack = snapshot->m_Stack;
+        RecoverFromSnapshot(snapshot);
+    } 
+
+    void VirtualMachine::RecoverFromSnapshot(const VMSnapshot& snapshot)
+    {
+        m_InstructionPointer = snapshot.m_InstructionPointer;
+        m_Instructions = snapshot.m_Instructions;
+        m_Constants = snapshot.m_Constants;
+        m_Environment = snapshot.m_Environment;
+        m_Stack = snapshot.m_Stack;
     }
   
     void VirtualMachine::VMLoop()

--- a/virtual-machine/src/virtual_machine.cpp
+++ b/virtual-machine/src/virtual_machine.cpp
@@ -9,12 +9,13 @@
 #include <shared/logger.h>
 #include <shared/objects/base_object.h>
 #include "register.h"
+#include "virtual-machine/exception_runtime.h"
 
 namespace vm
 {
 
     VirtualMachine::VirtualMachine()
-       : m_Instructions{0}, m_Environment{}, m_InstructionPointer{0}, m_VMContext{m_Environment, m_Constants, m_Stack, m_IsHalted, m_ErrorContext}
+       : m_Instructions{0}, m_Environment{}, m_InstructionPointer{0}, m_VMContext{m_Environment, m_Constants, m_Stack, m_IsHalted, m_ErrorContext}, m_ErrorContext()
     {
     }
 
@@ -28,28 +29,61 @@ namespace vm
         m_ExecutionDispatcher.Dispatch(m_VMContext, instruction);
     }
 
-    void VirtualMachine::Interpret(VMInterpretProperties &props)
+    std::expected<void, bool> VirtualMachine::Interpret(VMInterpretProperties &props)
     {
         m_Instructions.reserve(m_Instructions.capacity() * 2); /** @todo Implement optimization. */
         m_Instructions.insert(m_Instructions.end(), std::make_move_iterator(props.m_Instructions.begin()), std::make_move_iterator(props.m_Instructions.end()));
         m_Constants.ReplaceConstants(std::move(props.m_Constants));
 
         VMLoop();
+
+        if(m_IsHalted) return std::unexpected<bool>(true);
+        return {};
     }
 
     bool VirtualMachine::IsHalted() const noexcept
     {
         return m_IsHalted;
     }
+      
+    void VirtualMachine::ResetErrors() noexcept
+    {
+        if(IsHalted() == false && m_ErrorContext.m_ErrorThrown == false) return;
+        m_IsHalted = false;
+        m_ErrorContext.ResetErrors();
+    }
+
+    std::unique_ptr<VMSnapshot> VirtualMachine::TakeSnapshot()
+    {
+        return std::make_unique<VMSnapshot>(m_Instructions, shared::ConstantPool(m_Constants), m_Environment, m_Stack, m_InstructionPointer);
+    }
+
+    void VirtualMachine::RecoverFromSnapshot(const VMSnapshot* snapshot)
+    {
+        ResetErrors();
+        if(snapshot == nullptr) return;  
+        m_InstructionPointer = snapshot->m_InstructionPointer;
+        m_Instructions = snapshot->m_Instructions;
+        m_Constants = snapshot->m_Constants;
+        m_Environment = snapshot->m_Environment;
+        m_Stack = snapshot->m_Stack;
+    }
   
     void VirtualMachine::VMLoop()
     {
-        while (m_InstructionPointer < m_Instructions.size() && !m_IsHalted)
+        try
         {
-            auto &instruction = m_Instructions[m_InstructionPointer];
-            Dispatch(instruction);
-            LOG_DEBUG("[VM] {:#x} executed.", static_cast<uint8_t>(instruction.m_Opcode)); /** @todo Implement better debugging for only debug build. */
-            m_InstructionPointer++;
+            while (m_InstructionPointer < m_Instructions.size() && !m_IsHalted)
+            {
+                auto &instruction = m_Instructions[m_InstructionPointer];
+                Dispatch(instruction);
+                LOG_DEBUG("[VM] {:#x} executed.", static_cast<uint8_t>(instruction.m_Opcode)); /** @todo Implement better debugging for only debug build. */
+                m_InstructionPointer++;
+            }
+        }
+        catch (const RuntimeException& ex)
+        {
+            m_IsHalted = true;
         }
     }
 


### PR DESCRIPTION
- All exceptions are now derived from std::runtime_exception
- VirtualMachine and Compiler logic is refactored to handle the exceptions inside try-catch blocks peacefully.
- VirtualMachine Snapshotting behavior is implemented so that REPL session can be maintained even after errors, and it can be restored to the last successful state.
- Further trivial changes to ConstantPool/Environment/StackContainer were made to ensure that they support the new snapshotting behavior.

Closes #5 